### PR TITLE
Running cpanm --verify also fetches CHECKSUMS 

### DIFF
--- a/lib/App/cpanminus/reporter.pm
+++ b/lib/App/cpanminus/reporter.pm
@@ -152,6 +152,7 @@ sub run {
 
     while (<$fh>) {
       if ( /^Fetching (\S+)/ ) {
+        next if /CHECKSUMS$/;
         $fetched = $1;
         $resource = $fetched unless $resource;
       }


### PR DESCRIPTION
Hi,

If cpanm fetches `CHECKSUMS`, reporting fails. This one liner ignores any `^Fetching.*CHECKSUMS$` in the build log.

Thanks!
