### PR TITLE
Don't give up after a failed send.

### DIFF
--- a/lib/App/cpanminus/reporter.pm
+++ b/lib/App/cpanminus/reporter.pm
@@ -258,7 +258,15 @@ sub make_report {
     comments       => $client->email,
     via            => $client->via,
   );
-  $reporter->send() || die $reporter->errstr();
+
+  try {
+    $reporter->send() || die $reporter->errstr();
+  }
+  catch {
+    print "Error while sending this report, continuing with the next one...\n" unless $self->quiet;
+    print "DEBUG: @_" if $self->verbose;
+  }
+
 }
 
 sub get_meta_for {


### PR DESCRIPTION
If for some reason the send action fails (unstable connection for
example), cpanm-reporter would die and the user would need to
restart from begin and this is bad because it will keep dying
everytime and it's almost impossible to send a big list of reports.

Now, cpanm-reporter warns the user that it failed for that one
(so the user may try to run cpanm-reporter again after) but continues
to the next report.

This should be enough to close #5.
