### PR TITLE
allow file scheme for installing/reporting out of a minicpan mirror

### DIFF
--- a/lib/App/cpanminus/reporter.pm
+++ b/lib/App/cpanminus/reporter.pm
@@ -272,6 +272,7 @@ sub make_report {
   if (    $scheme ne 'http'
       and $scheme ne 'ftp'
       and $scheme ne 'cpan'
+      and $scheme ne 'file'
   ) {
     print "invalid scheme '$scheme' for resource '$resource'. Skipping...\n"
       unless $self->quiet;


### PR DESCRIPTION
This allows sending reports that were installed from a local minicpan mirror.
