### PR TITLE
don't report on dist owned by LOCAL

### DIFF
--- a/lib/App/cpanminus/reporter.pm
+++ b/lib/App/cpanminus/reporter.pm
@@ -284,6 +284,11 @@ sub make_report {
       unless $self->quiet;
     return;
   }
+  
+  if ($author eq 'LOCAL') {
+    print "skipping: ($resource, $author, $dist, $result)\n" unless $self->quiet;
+    return;
+  }
 
   print "sending: ($resource, $author, $dist, $result)\n" unless $self->quiet;
 


### PR DESCRIPTION
This skips dists owned by LOCAL, which I think most of the time is the right thing to do (?).

An option to specify users to skip might also be useful.
