### PR TITLE
support https

### DIFF
--- a/lib/App/cpanminus/reporter.pm
+++ b/lib/App/cpanminus/reporter.pm
@@ -303,6 +303,7 @@ sub parse_uri {
   my $uri = URI->new( $resource );
   my $scheme = lc $uri->scheme;
   if (    $scheme ne 'http'
+      and $scheme ne 'https'
       and $scheme ne 'ftp'
       and $scheme ne 'cpan'
   ) {


### PR DESCRIPTION
metacpan now defaults to https so cut/pasting URLs from the
doesn't work with cpanminus reporter unless you change the
protocol in the URL