### PR TITLE
Publish multiple reports

### DIFF
--- a/bin/cpanm-reporter
+++ b/bin/cpanm-reporter
@@ -7,7 +7,8 @@ use Getopt::Long;
 use Pod::Usage;
 
 my %options = ();
-GetOptions( \%options, qw(build_dir=s build_logfile=s verbose|v force quiet|q
+GetOptions( \%options, qw(build_dir=s build_logfile=s max_age=i all|a
+                          verbose|v force quiet|q
                           setup version help exclude=s only=s dry-run)
 ) or pod2usage();
 
@@ -49,9 +50,16 @@ Call cpanm as you normally would:
 
    > cpanm Moose Catalyst::Runtime Data::Printer ...
 
-then, just call cpanm-reporter:
+then, just call cpanm-reporter to report results:
 
    > cpanm-reporter
+
+Or, if you performed a few installs (called cpanm more than once)
+and wish to report them all:
+
+   > cpanm-reporter --all
+
+See also some more advanced options below.
 
 =head2 OPTIONAL ARGUMENTS
 
@@ -60,9 +68,20 @@ then, just call cpanm-reporter:
    --help                 Shows basic usage help and exits
 
    --build_dir=PATH       Where your build directory is, containing
-                          each dist's subdir. Default: $HOME/.cpanm/latest-build
+                          each dist's subdir. Default:
+                          $HOME/.cpanm/latest-build
 
-   --build_logfile=PATH   Where the build.log is. Default: $BUILD_DIR/build.log
+   --build_logfile=PATH   Report results based on this specific build.log.
+                          By default: $BUILD_DIR/build.log is checked.
+
+   --all (or -a)          Report all recent installations, not only the
+                          last one. Use if you called cpanm a few times
+                          before spawning cpanm-reporter.
+
+   --max_age=AGE          Max age (in minutes) of reports which may
+                          be processed. See remarks below. Default: 30.
+
+   --force                Process reports even if they are too old.
 
    --verbose (or -v)      Extra output
 
@@ -73,7 +92,7 @@ then, just call cpanm-reporter:
    --only=A::B,C::D,...   Only send reports for these modules
 
    --exclude=A::B,...     Don't send reports for these modules
-   
+
    --dry-run              Prepare, but do not actually send reports
 
 
@@ -122,9 +141,10 @@ As such, you must be cautious to only run this tool I<right after> you run
 cpanm, otherwise your whole environment may have changed, rendering the
 report useless - maybe even turning it into a disservice.
 
-B<< As such, we will *only* parse build.log files last modified up to 30
-minutes before. >> You can override this by passing the C<--force> flag
-to cpanm-reporter, but please take good care to avoid sending bogus reports.
+B<< As such, we will *only* parse build.log files last modified up to
+30 minutes before. >> You can override this by passing the
+C<--max_age=...> option or the C<--force> flag to cpanm-reporter, but
+please take good care to avoid sending bogus reports.
 
 
 =item * cpanm currently does B<not> record the output into your build.log file

--- a/lib/App/cpanminus/reporter.pm
+++ b/lib/App/cpanminus/reporter.pm
@@ -177,15 +177,15 @@ sub _check_cpantesters_config_data {
 }
 
 sub _check_build_log {
-  my $self = shift;
+  my ($self, $build_logfile) = @_;
 
   # as a safety mechanism, we only let people parse build.log files
   # if they were generated up to 30 minutes (1800 seconds) ago,
   # unless the user asks us to --force it.
-  my $mtime = (stat $self->build_logfile)[9];
+  my $mtime = (stat $build_logfile)[9];
   if ( !$self->force && $mtime && time - $mtime > 1800 ) {
       print <<'EOMESSAGE';
-Fatal: build.log was created longer than 30 minutes ago.
+$build_logfile was created more than 30 minutes ago.
 
 As a standalone tool, it is important that you run cpanm-reporter
 as soon as you finish cpanm, otherwise your system data may have
@@ -205,9 +205,15 @@ EOMESSAGE
 
 sub run {
   my $self = shift;
-  return unless ($self->_check_cpantesters_config_data and $self->_check_build_log);
+  return unless $self->_check_cpantesters_config_data;
+  $self->process_logfile($self->build_logfile);
+}
 
-  my $logfile = $self->build_logfile;
+sub process_logfile {
+  my ($self, $logfile) = @_;
+
+  return unless $self->_check_build_log($logfile);
+
   open my $fh, '<', $logfile
     or Carp::croak "error opening build log file '$logfile' for reading: $!";
 

--- a/lib/App/cpanminus/reporter.pm
+++ b/lib/App/cpanminus/reporter.pm
@@ -3,7 +3,7 @@ package App::cpanminus::reporter;
 use warnings;
 use strict;
 
-our $VERSION = '0.11';
+our $VERSION = '0.12';
 
 use Carp ();
 use File::Spec     3.19;


### PR DESCRIPTION
I offer two new options (sorry for bundling them together but I added --max-age after trying to use --all):

--all
     causes cpanm-reporter to consider not only last build.log, but also other recent build.log 
     files present in ~/cpanm/work. I wrote it as I routinely
            cpanm OnePackage
            cpanm SecondOne
            cpanm-reporter   # Ops, only Second reported

--max-age=60
     specify max allowed age of build.log, in minutes. This is safer than full-blown force, especially
     in case --all is being used.

There are also some tweaks in doc and messages to accomodate those changes, and minor refactoring to make processing multiple build.log's easier.
