### PR TITLE
Fix for ExtUtils::Manifest=fullcheck -e fullcheck warnings

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -3,7 +3,8 @@ Changes
 lib/App/cpanminus/reporter.pm
 Makefile.PL
 MANIFEST			This list of files
-README
+MANIFEST.SKIP			Stuff that should be skipped
+README.md
 t/00.load.t
 t/01.basic.t
 t/02.parser.single.t

--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -1,0 +1,3 @@
+.travis.yml
+.git
+.git/*


### PR DESCRIPTION
Created MANIFEST.SKIP to tell CPAN to ignore the .travis.yml file.
Updated MANIFEST to list README.md instead of README and added
MANIFEST.SKIP to the list.