### PR TITLE
Added minimum Perl version to Makefile.PL to improve kwalitee score

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -9,6 +9,7 @@ WriteMakefile(
     ABSTRACT_FROM       => 'lib/App/cpanminus/reporter.pm',
     LICENSE             => 'perl',
     PL_FILES            => {},
+    MIN_PERL_VERSION    => '5.8.1',
     PREREQ_PM => {
         'CPAN::Meta::Converter'         => 0,
         'CPAN::Testers::Common::Client' => 0.10,


### PR DESCRIPTION
As far as I can tell, the minimum version could be 5.6.0 However, I chose 5.8.1 because this is required by cpanm and it seemed pointless to specify less than that.
This was done as part of CPAN Pull Request Challenge.