### PR TITLE
Check to prevent Perl version mismatch in reports

### DIFF
--- a/bin/cpanm-reporter
+++ b/bin/cpanm-reporter
@@ -9,7 +9,7 @@ use Pod::Usage;
 my %options = ();
 GetOptions( \%options, qw(build_dir=s build_logfile=s verbose|v force quiet|q
                           setup version help exclude=s only=s dry-run
-                          skip-history)
+                          skip-history ignore-versions)
 ) or pod2usage();
 
 if ($options{help}) {
@@ -141,6 +141,13 @@ installing distributions with C<cpanm> and generating/sending the reports with
 C<cpanm-reporter>. If you're not a power user, you don't have to worry about
 this. Just remember to run cpanm-reporter immediately after cpanm and
 everything will be fine :)
+
+As an added precaution, cpanm-reporter will skip build.log entries in which
+the Perl version recorded in the build.log is different than the Perl version
+that is generating the report. The entries will be skipped silently unless
+the C<--verbose> or C<-v> flag is passed. This version check can be ignored
+by passing the C<--ignore-versions> flag to cpanm-reporter. Obviously, this
+is discouraged since it would result in the sending of bogus reports.
 
 =back
 

--- a/lib/App/cpanminus/reporter.pm
+++ b/lib/App/cpanminus/reporter.pm
@@ -50,7 +50,7 @@ sub new {
       || File::Spec->catfile( $self->build_dir, 'build.log' )
   );
 
-  foreach my $option ( qw(quiet verbose force exclude only dry-run skip-history) ) {
+  foreach my $option ( qw(quiet verbose force exclude only dry-run skip-history ignore-versions) ) {
     my $method = $option;
     $method =~ s/\-/_/g;
     $self->$method( $params{$option} ) if exists $params{$option};
@@ -91,6 +91,12 @@ sub force {
   my ($self, $force) = @_;
   $self->{_force} = $force if $force;
   return $self->{_force};
+}
+
+sub ignore_versions {
+  my ($self, $ignore_versions) = @_;
+  $self->{_ignore_versions} = $ignore_versions if $ignore_versions;
+  return $self->{_ignore_versions};
 }
 
 sub quiet {
@@ -275,6 +281,9 @@ sub run {
         }
         elsif ( defined $self->only && !exists $self->only->{$dist_without_version} ) {
             print "Skipping $dist as it isn't in the 'only' list...\n" if $self->verbose;
+        }
+        elsif ( !$self->ignore_versions && defined $self->{_perl_version} && ( $self->{_perl_version} ne $] ) ) {
+            print "Skipping $dist as it's build Perl version ($self->{_perl_version}) differs from the currently running perl ($])...\n" if $self->verbose;
         }
         else {
             my $report = $self->make_report($resource, $dist, $result, @test_output);

--- a/t/02.parser.single.t
+++ b/t/02.parser.single.t
@@ -7,6 +7,7 @@ my $dir = -d 't' ? 't/data' : 'data';
 ok my $reporter = App::cpanminus::reporter->new(
   force => 1, # ignore mtime check on build.log
   build_logfile => $dir . '/build.single.log', 
+  ignore_versions => 1,
 ), 'created new reporter object';
 
 sub test_make_report {

--- a/t/02.parser.single.t
+++ b/t/02.parser.single.t
@@ -7,7 +7,7 @@ my $dir = -d 't' ? 't/data' : 'data';
 ok my $reporter = App::cpanminus::reporter->new(
   force => 1, # ignore mtime check on build.log
   build_logfile => $dir . '/build.single.log', 
-  ignore_versions => 1,
+  'ignore-versions' => 1,
 ), 'created new reporter object';
 
 sub test_make_report {

--- a/t/03.parser.single_extended.t
+++ b/t/03.parser.single_extended.t
@@ -7,7 +7,7 @@ my $dir = -d 't' ? 't/data' : 'data';
 ok my $reporter = App::cpanminus::reporter->new(
   force => 1, # ignore mtime check on build.log
   build_logfile => $dir . '/build.single_extended.log', 
-  ignore_versions => 1,
+  'ignore-versions' => 1,
 ), 'created new reporter object';
 
 sub test_make_report {

--- a/t/03.parser.single_extended.t
+++ b/t/03.parser.single_extended.t
@@ -7,6 +7,7 @@ my $dir = -d 't' ? 't/data' : 'data';
 ok my $reporter = App::cpanminus::reporter->new(
   force => 1, # ignore mtime check on build.log
   build_logfile => $dir . '/build.single_extended.log', 
+  ignore_versions => 1,
 ), 'created new reporter object';
 
 sub test_make_report {

--- a/t/04.parser.nothing_to_do.t
+++ b/t/04.parser.nothing_to_do.t
@@ -7,7 +7,7 @@ my $dir = -d 't' ? 't/data' : 'data';
 ok my $reporter = App::cpanminus::reporter->new(
   force => 1, # ignore mtime check on build.log
   build_logfile => $dir . '/build.nothing_to_do.log', 
-  ignore_versions => 1,
+  'ignore-versions' => 1,
 ), 'created new reporter object';
 
 sub test_make_report {

--- a/t/04.parser.nothing_to_do.t
+++ b/t/04.parser.nothing_to_do.t
@@ -7,6 +7,7 @@ my $dir = -d 't' ? 't/data' : 'data';
 ok my $reporter = App::cpanminus::reporter->new(
   force => 1, # ignore mtime check on build.log
   build_logfile => $dir . '/build.nothing_to_do.log', 
+  ignore_versions => 1,
 ), 'created new reporter object';
 
 sub test_make_report {

--- a/t/05.parser.configure_failed.t
+++ b/t/05.parser.configure_failed.t
@@ -7,7 +7,7 @@ my $dir = -d 't' ? 't/data' : 'data';
 ok my $reporter = App::cpanminus::reporter->new(
   force => 1, # ignore mtime check on build.log
   build_logfile => $dir . '/build.configure_failed.log', 
-  ignore_versions => 1,
+  'ignore-versions' => 1,
 ), 'created new reporter object';
 
 sub test_make_report {

--- a/t/06.parser.version_strings.t
+++ b/t/06.parser.version_strings.t
@@ -7,7 +7,7 @@ my $dir = -d 't' ? 't/data' : 'data';
 ok my $reporter = App::cpanminus::reporter->new(
   force => 1, # ignore mtime check on build.log
   build_logfile => $dir . '/build.version_strings.log', 
-  ignore_versions => 1,
+  'ignore-versions' => 1,
 ), 'created new reporter object';
 
 sub test_make_report {

--- a/t/06.parser.version_strings.t
+++ b/t/06.parser.version_strings.t
@@ -7,6 +7,7 @@ my $dir = -d 't' ? 't/data' : 'data';
 ok my $reporter = App::cpanminus::reporter->new(
   force => 1, # ignore mtime check on build.log
   build_logfile => $dir . '/build.version_strings.log', 
+  ignore_versions => 1,
 ), 'created new reporter object';
 
 sub test_make_report {

--- a/t/07.parser.module_dir.t
+++ b/t/07.parser.module_dir.t
@@ -7,6 +7,7 @@ my $dir = -d 't' ? 't/data' : 'data';
 ok my $reporter = App::cpanminus::reporter->new(
   force => 1, # ignore mtime check on build.log
   build_logfile => $dir . '/build.module_dir.log', 
+  ignore_versions => 1,
 ), 'created new reporter object';
 
 

--- a/t/07.parser.module_dir.t
+++ b/t/07.parser.module_dir.t
@@ -7,7 +7,7 @@ my $dir = -d 't' ? 't/data' : 'data';
 ok my $reporter = App::cpanminus::reporter->new(
   force => 1, # ignore mtime check on build.log
   build_logfile => $dir . '/build.module_dir.log', 
-  ignore_versions => 1,
+  'ignore-versions' => 1,
 ), 'created new reporter object';
 
 

--- a/t/07.parser.verbose_cpanm.t
+++ b/t/07.parser.verbose_cpanm.t
@@ -8,7 +8,7 @@ my $dir = -d 't' ? 't/data' : 'data';
 ok my $reporter = App::cpanminus::reporter->new(
   force => 1, # ignore mtime check on build.log
   build_logfile => $dir . '/build.verbose_cpanm.log', 
-  ignore_versions => 1,
+  'ignore-versions' => 1,
 ), 'created new reporter object';
 
 sub test_make_report {

--- a/t/07.parser.verbose_cpanm.t
+++ b/t/07.parser.verbose_cpanm.t
@@ -8,6 +8,7 @@ my $dir = -d 't' ? 't/data' : 'data';
 ok my $reporter = App::cpanminus::reporter->new(
   force => 1, # ignore mtime check on build.log
   build_logfile => $dir . '/build.verbose_cpanm.log', 
+  ignore_versions => 1,
 ), 'created new reporter object';
 
 sub test_make_report {

--- a/t/08.parser.dist_subdir.t
+++ b/t/08.parser.dist_subdir.t
@@ -7,6 +7,7 @@ my $dir = -d 't' ? 't/data' : 'data';
 ok my $reporter = App::cpanminus::reporter->new(
   force => 1, # ignore mtime check on build.log
   build_logfile => $dir . '/build.dist_subdir.log', 
+  ignore_versions => 1,
 ), 'created new reporter object';
 
 sub test_make_report {

--- a/t/08.parser.dist_subdir.t
+++ b/t/08.parser.dist_subdir.t
@@ -7,7 +7,7 @@ my $dir = -d 't' ? 't/data' : 'data';
 ok my $reporter = App::cpanminus::reporter->new(
   force => 1, # ignore mtime check on build.log
   build_logfile => $dir . '/build.dist_subdir.log', 
-  ignore_versions => 1,
+  'ignore-versions' => 1,
 ), 'created new reporter object';
 
 sub test_make_report {

--- a/t/09.parser.dist_subdir2.t
+++ b/t/09.parser.dist_subdir2.t
@@ -11,7 +11,7 @@ ok my $reporter = App::cpanminus::reporter->new(
   build_logfile  => $dir . '/build.dist_subdir.log',
   quiet          => 1,
   'skip-history' => 1,
-  ignore_versions => 1,
+  'ignore-versions' => 1,
 ), 'created new reporter object';
 
 sub test_reporter_new {

--- a/t/09.parser.dist_subdir2.t
+++ b/t/09.parser.dist_subdir2.t
@@ -11,6 +11,7 @@ ok my $reporter = App::cpanminus::reporter->new(
   build_logfile  => $dir . '/build.dist_subdir.log',
   quiet          => 1,
   'skip-history' => 1,
+  ignore_versions => 1,
 ), 'created new reporter object';
 
 sub test_reporter_new {

--- a/t/10.parser.cloudweights.t
+++ b/t/10.parser.cloudweights.t
@@ -7,7 +7,7 @@ my $dir = -d 't' ? 't/data' : 'data';
 ok my $reporter = App::cpanminus::reporter->new(
   force => 1, # ignore mtime check on build.log
   build_logfile => $dir . '/build.cloudweights.log', 
-  ignore_versions => 1,
+  'ignore-versions' => 1,
 ), 'created new reporter object';
 
 my $current_report_id = 0;

--- a/t/10.parser.cloudweights.t
+++ b/t/10.parser.cloudweights.t
@@ -7,6 +7,7 @@ my $dir = -d 't' ? 't/data' : 'data';
 ok my $reporter = App::cpanminus::reporter->new(
   force => 1, # ignore mtime check on build.log
   build_logfile => $dir . '/build.cloudweights.log', 
+  ignore_versions => 1,
 ), 'created new reporter object';
 
 my $current_report_id = 0;

--- a/t/11.local.t
+++ b/t/11.local.t
@@ -20,7 +20,7 @@ ok my $reporter = App::cpanminus::reporter->new(
     build_logfile  => $dir . 'build.single.log',
     quiet          => 1,
     'skip-history' => 1,
-    ignore_versions => 1,
+    'ignore-versions' => 1,
 ), 'created new reporter object';
 
 is $reporter->quiet, 1, 'reporter is quiet';

--- a/t/11.local.t
+++ b/t/11.local.t
@@ -20,6 +20,7 @@ ok my $reporter = App::cpanminus::reporter->new(
     build_logfile  => $dir . 'build.single.log',
     quiet          => 1,
     'skip-history' => 1,
+    ignore_versions => 1,
 ), 'created new reporter object';
 
 is $reporter->quiet, 1, 'reporter is quiet';

--- a/t/12.parser.version_mismatch.t
+++ b/t/12.parser.version_mismatch.t
@@ -6,20 +6,13 @@ use App::cpanminus::reporter;
 my $dir = -d 't' ? 't/data' : 'data';
 ok my $reporter = App::cpanminus::reporter->new(
   force => 1, # ignore mtime check on build.log
-  build_logfile => $dir . '/build.configure_failed.log', 
-  ignore_versions => 1,
+  build_logfile => $dir . '/build.version_mismatch.log',
 ), 'created new reporter object';
-
-sub test_make_report {
-  fail 'make_report() should never be reached by the parser';
-}
 
 {
   no warnings 'redefine';
   local *App::cpanminus::reporter::_check_cpantesters_config_data = sub { 1 };
-  local *App::cpanminus::reporter::make_report = \&test_make_report;
-  $reporter->run;
-};
 
-pass 'parser runs on build.log where configure failed';
+  is($reporter->run, undef, "skipped due to version, undefined as expected");
+};
 

--- a/t/data/build.version_mismatch.log
+++ b/t/data/build.version_mismatch.log
@@ -1,0 +1,43 @@
+cpanm (App::cpanminus) 1.7034 on perl 5.006000 built for darwin-2level
+Work directory is /Users/lagrasta/.cpanm/work/1438721993.73742
+You have make /usr/bin/make
+You have LWP 6.13
+You have /usr/bin/tar: bsdtar 2.8.3 - libarchive 2.8.3
+You have /usr/bin/unzip
+Searching Params::Check () on cpanmetadb ...
+--> Working on Params::Check
+Fetching http://www.cpan.org/authors/id/B/BI/BINGOS/Params-Check-0.38.tar.gz
+-> OK
+Unpacking Params-Check-0.38.tar.gz
+Entering Params-Check-0.38
+Checking configure dependencies from META.json
+Checking if you have ExtUtils::MakeMaker 6.58 ... Yes (6.98)
+Configuring Params-Check-0.38
+Running Makefile.PL
+Checking if your kit is complete...
+Looks good
+Generating a Unix-style Makefile
+Writing Makefile for Params::Check
+Writing MYMETA.yml and MYMETA.json
+-> OK
+Checking dependencies from MYMETA.json ...
+Checking if you have ExtUtils::MakeMaker 0 ... Yes (6.98)
+Checking if you have Test::More 0 ... Yes (1.001014)
+Checking if you have Locale::Maketext::Simple 0 ... Yes (0.21)
+Building and testing Params-Check-0.38
+cp lib/Params/Check.pm blib/lib/Params/Check.pm
+Manifying blib/man3/Params::Check.3
+PERL_DL_NONLAZY=1 /Users/lagrasta/.plenv/versions/5.20.2/bin/perl5.20.2 "-MExtUtils::Command::MM" "-MTest::Harness" "-e" "undef *Test::Harness::Switches; test_harness(0, 'blib/lib', 'blib/arch')" t/*.t
+t/01_Params-Check.t .. ok
+All tests successful.
+Files=1, Tests=91,  0 wallclock secs ( 0.02 usr  0.01 sys +  0.03 cusr  0.00 csys =  0.06 CPU)
+Result: PASS
+Manifying blib/man3/Params::Check.3
+Installing /Users/lagrasta/.plenv/versions/5.20.2/lib/perl5/5.20.2/Params/Check.pm
+Installing /Users/lagrasta/.plenv/versions/5.20.2/man/man3/Params::Check.3
+Appending installation info to /Users/lagrasta/.plenv/versions/5.20.2/lib/perl5/5.20.2/darwin-2level/perllocal.pod
+-> OK
+Successfully installed Params-Check-0.38
+Installing /Users/lagrasta/.plenv/versions/5.20.2/lib/perl5/site_perl/5.20.2/darwin-2level/.meta/Params-Check-0.38/install.json
+Installing /Users/lagrasta/.plenv/versions/5.20.2/lib/perl5/site_perl/5.20.2/darwin-2level/.meta/Params-Check-0.38/MYMETA.json
+1 distribution installed


### PR DESCRIPTION
Added a version check to prevent the submission of a report where the Perl version provided by the build.log entry does not match the Perl version which is being used to generate the report. The goal of this is to reduce invalid reports that can easily occur while using a more advanced Perl deployment scheme such as PerlBrew or plenv. I've also added a command line parameter to bypass this check has been added. Tests have been added and updated as needed.

Unfortunately, I had to modify most of the existing tests to pass in the --ignore-version flag since the versions in the test build.log files would almost never match the current Perl version. I considered updating the tests to create their data files on demand but decided the more minimal modifications were best for now.

This may be a solution for CPAN RT bug 102995 https://rt.cpan.org/Public/Bug/Display.html?id=102995 . However, it is unclear to me if that bug is implying a deeper issue in version detection in the case of PerlBrew/plenv.