### PR TITLE
switch from File::HomeDir to ::Tiny

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,32 @@
 language: perl
 perl:
+  - "5.28"
+  - "5.26"
+  - "5.24"
+  - "5.22"
   - "5.20"
+  - "5.18"
+  - "5.16"
+  - "5.14"
+  - "5.12"
+  - "5.10"
   - "5.8"
-
+env:
+  global:
+    - RELEASE_TESTING=1
+    - AUTOMATED_TESTING=1
+    - AUTHOR_TESTING=1
+    - HARNESS_OPTIONS=c
+    - HARNESS_TIMER=1
+matrix:
+  include:
+    - perl: "5.20"
+      env: COVERAGE=1
+      script:
+        - PERL5OPT=-MDevel::Cover=-coverage,statement,branch,condition,path,subroutine prove -lrsv t
+        - cover
+      after_success:
+        - cover -report coveralls
 install:
-     - export RELEASE_TESTING=1 AUTOMATED_TESTING=1 AUTHOR_TESTING=1 HARNESS_OPTIONS=c HARNESS_TIMER=1
-     - cpanm --quiet --notest Devel::Cover::Report::Coveralls
-     - cpanm --quiet --notest --installdeps .
-
-script:
-     - PERL5OPT=-MDevel::Cover=-coverage,statement,branch,condition,path,subroutine prove -lrsv t
-     - cover
-
-after_success:
-    - cover -report coveralls
+  - cpanm --quiet --notest Devel::Cover::Report::Coveralls
+  - cpanm --quiet --notest --installdeps .

--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 Revision history for App-cpanminus-reporter
 
+    OTHER:
+      - reduced prereq tree by switching from File::HomeDir to
+        File::HomeDir::Tiny.
+
 0.17 2016-04-24
     BUG FIXES:
         - fixed support for extended paths on Windows

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -19,7 +19,7 @@ WriteMakefile(
         'Capture::Tiny'                 => 0,
         'Carp'                          => 0,
         'Config::Tiny'                  => 2.08,
-        'File::HomeDir'                 => 0.58,
+        'File::HomeDir::Tiny'           => 0,
         'File::Spec'                    => 3.19,
         'Getopt::Long'                  => 0,
         'IO::Prompt::Tiny'              => 0,

--- a/lib/App/cpanminus/reporter.pm
+++ b/lib/App/cpanminus/reporter.pm
@@ -7,7 +7,7 @@ our $VERSION = '0.17';
 
 use Carp ();
 use File::Spec     3.19;
-use File::HomeDir  0.58 ();
+use File::HomeDir::Tiny ();
 use Test::Reporter 1.54;
 use CPAN::Testers::Common::Client 0.13;
 use CPAN::Testers::Common::Client::Config;
@@ -42,7 +42,7 @@ sub new {
 
   $self->build_dir(
     $params{build_dir}
-      || File::Spec->catdir( File::HomeDir->my_home, '.cpanm' )
+      || File::Spec->catdir( File::HomeDir::Tiny::home(), '.cpanm' )
   );
 
   $self->build_logfile(


### PR DESCRIPTION
File::HomeDir has a lot of prereqs and also some  architecture-specific
dynamic dependencies, none of which are needed here for the simple
homedir case.