### PR TITLE
remove use of File::HomeDir::Tiny

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for App-cpanminus-reporter
 
+    BUG FIXES:
+      - remove use of File::HomeDir::Tiny, to enable use on perl 5.41.3+.
+
 0.21 2023-07-19
     BUG FIXES:
       - fix tarball issue that prevented installation on FreeBSD

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -19,7 +19,6 @@ WriteMakefile(
         'Capture::Tiny'                 => 0,
         'Carp'                          => 0,
         'Config::Tiny'                  => 2.08,
-        'File::HomeDir::Tiny'           => 0,
         'File::Spec'                    => 3.19,
         'Getopt::Long'                  => 0,
         'IO::Prompt::Tiny'              => 0,

--- a/lib/App/cpanminus/reporter.pm
+++ b/lib/App/cpanminus/reporter.pm
@@ -7,7 +7,6 @@ our $VERSION = '0.21';
 
 use Carp ();
 use File::Spec     3.19;
-use File::HomeDir::Tiny ();
 use Test::Reporter 1.54;
 use CPAN::Testers::Common::Client 0.13;
 use CPAN::Testers::Common::Client::Config;
@@ -42,7 +41,7 @@ sub new {
 
   $self->build_dir(
     $params{build_dir}
-      || File::Spec->catdir( File::HomeDir::Tiny::home(), '.cpanm' )
+      || File::Spec->catdir( _home(), '.cpanm' )
   );
 
   $self->build_logfile(
@@ -575,6 +574,11 @@ sub get_meta_for {
   return;
 }
 
+sub _home {
+  $^O eq 'MSWin32' && "$]" < 5.016
+    ? $ENV{HOME} || $ENV{USERPROFILE}
+    : (<~>)[0]
+}
 
 42;
 __END__


### PR DESCRIPTION
version 0.01 does not run on perls 5.41.3+ (due to use of ' as a package separator), and also there was a typo that prevented proper use on MSWin32.